### PR TITLE
Fix: CLI clash

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -14,7 +14,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/fastify-vite-plugin-ssr/package.json
+++ b/examples/fastify-vite-plugin-ssr/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1",
     "vite-plugin-ssr": "^0.4.101"
   }

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/hapi/package.json
+++ b/examples/hapi/package.json
@@ -14,7 +14,7 @@
     "@types/hapi__hapi": "^21.0.0",
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/koa/package.json
+++ b/examples/koa/package.json
@@ -15,7 +15,7 @@
     "@types/koa__router": "^12.0.0",
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/nestjs-vite-plugin-ssr/package.json
+++ b/examples/nestjs-vite-plugin-ssr/package.json
@@ -19,7 +19,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "rollup-plugin-swc3": "^0.8.0",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1",
     "vite-tsconfig-paths": "^4.0.7"
   },

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^18.15.5",
     "rollup-plugin-swc3": "^0.8.0",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/simple-standalone/package.json
+++ b/examples/simple-standalone/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   }
 }

--- a/examples/socket-io/package.json
+++ b/examples/socket-io/package.json
@@ -14,7 +14,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^18.15.5",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/ssr-react-express/package.json
+++ b/examples/ssr-react-express/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/ssr-vue-express/package.json
+++ b/examples/ssr-vue-express/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^18.15.5",
     "@vitejs/plugin-vue": "^4.1.0",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1"
   },
   "dependencies": {

--- a/examples/vite-plugin-ssr/package.json
+++ b/examples/vite-plugin-ssr/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
-    "vavite": "1.8.0",
+    "vavite": "1.8.1",
     "vite": "^4.2.1",
     "vite-plugin-ssr": "^0.4.101"
   }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/connect",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/expose-vite-dev-server/package.json
+++ b/packages/expose-vite-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/expose-vite-dev-server",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "module": "./dist/index.mjs",
   "files": [
     "dist",

--- a/packages/multibuild-cli/package.json
+++ b/packages/multibuild-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@vavite/multibuild-cli",
   "version": "1.8.0",
   "bin": {
-    "vavite": "./cli.js"
+    "vavite-multibuild": "./cli.js"
   },
   "main": "./cli.js",
   "files": [

--- a/packages/multibuild-cli/package.json
+++ b/packages/multibuild-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/multibuild-cli",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "bin": {
     "vavite-multibuild": "./cli.js"
   },

--- a/packages/multibuild-cli/readme.md
+++ b/packages/multibuild-cli/readme.md
@@ -2,9 +2,9 @@
 
 `@vavite/multibuild-cli` is a tool for orchestrating multiple [Vite](https://vitejs.dev) builds. This package is the CLI binary, check out [`@vavite/multibuild`](../multibuild) for the JavaScript API.
 
-Developing applications that perform server-side rendering (SSR) with Vite requires two separate build steps: one for the client and one for the server. This library allows you to run both builds in a and customize the configuration for each build.
+Developing applications that perform server-side rendering (SSR) with Vite requires two separate build steps: one for the client and one for the server. This library allows you to run both builds with a single command and customize the configuration for each build.
 
-We're hoping that, eventually, [this feature will be implemented in Vite itself](https://github.com/vitejs/vite/issues/5936). This package exists to provide workaround until then.
+We're hoping that, eventually, [this feature will be implemented in Vite itself](https://github.com/vitejs/vite/issues/5936). This package exists to provide a workaround until then.
 
 ## Usage
 
@@ -41,7 +41,7 @@ export default defineConfig({
 });
 ```
 
-You can then run the `vavite` command as a drop-in replacement for `vite build`. This will call `resolveConfig` with the `mode` parameter set to `"multibuild"` to extract the build steps. Setting `buildSteps` in subsequent steps has no effect.
+You can then run the `vavite-multibuild` command as a drop-in replacement for `vite build`. This will call `resolveConfig` with the `mode` parameter set to `"multibuild"` to extract the build steps. Setting `buildSteps` in subsequent steps has no effect.
 
 ## Sharing information between builds
 

--- a/packages/multibuild/package.json
+++ b/packages/multibuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/multibuild",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/node-loader/package.json
+++ b/packages/node-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/node-loader",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/reloader/package.json
+++ b/packages/reloader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vavite/reloader",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "module": "./dist/index.mjs",
   "files": [
     "dist",

--- a/packages/vavite/package.json
+++ b/packages/vavite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vavite",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A Vite plugin for develoing server-side applications",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -80,7 +80,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -122,7 +122,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -147,7 +147,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -175,7 +175,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -215,7 +215,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -279,7 +279,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -297,7 +297,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -322,7 +322,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -359,7 +359,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -387,7 +387,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1
@@ -429,7 +429,7 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vavite:
-        specifier: 1.8.0
+        specifier: 1.8.1
         version: link:../../packages/vavite
       vite:
         specifier: ^4.2.1


### PR DESCRIPTION
CLI binaries from `@vavite/multibuild-cli` and `vavite` packages were both named `vavite` which caused conflicts when with `npm` (but not `pnpm`). This PR solves it by renaming the `@vavite/multibuild-cli` binary as `vavite-multibuild`.

Fixes #41