### PR TITLE
Expose type definition on exports

### DIFF
--- a/packages/vavite/package.json
+++ b/packages/vavite/package.json
@@ -17,10 +17,16 @@
       "require": "./dist/index.cjs"
     },
     "./vite-dev-server": {
-      "import": "./dist/vite-dev-server.js"
+      "import": {
+        "types": "./vite-dev-server.d.ts",
+        "default": "./dist/vite-dev-server.js"
+      }
     },
     "./http-dev-server": {
-      "import": "./dist/http-dev-server.js"
+      "import": {
+        "types": "./http-dev-server.d.ts",
+        "default": "./dist/http-dev-server.js"
+      }
     },
     "./node-loader": "./node-loader.mjs",
     "./suppress-loader-warnings": "./suppress-loader-warnings.cjs",


### PR DESCRIPTION
Fixes below issue when import `vavite/vite-dev-server` or `vavite/http-dev-server` in typescript file.

```
  There are types at '{some path}/node_modules/vavite/vite-dev-server.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vavite' library may need to update its package.json or typings.ts(7016)
```

reference:
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing