### PR TITLE
fix(nestjs-vite-plugin-ssr): example updated to support latest versions

### DIFF
--- a/examples/nestjs-vite-plugin-ssr/vite.config.ts
+++ b/examples/nestjs-vite-plugin-ssr/vite.config.ts
@@ -3,7 +3,7 @@ import vavite from "vavite";
 import { swc } from "rollup-plugin-swc3";
 import react from "@vitejs/plugin-react";
 import ssr from "vite-plugin-ssr/plugin";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { join } from "node:path";
 
 export default defineConfig({
 	buildSteps: [
@@ -25,6 +25,10 @@ export default defineConfig({
 		{
 			...swc({
 				jsc: {
+					baseUrl: join(__dirname, "./src"),
+					paths: {
+						"*": ["*"],
+					},
 					transform: {
 						decoratorMetadata: true,
 						legacyDecorator: true,
@@ -40,6 +44,5 @@ export default defineConfig({
 		}),
 		react(),
 		ssr({ disableAutoFullBuild: true }),
-		tsconfigPaths(),
 	],
 });


### PR DESCRIPTION
* `vite-tsconfig-paths` no longer supported with vite-plugin-ssr
  > Error: [vite-plugin-ssr][Wrong Usage] vite-tsconfig-paths not supported, remove it and use vite.config.js#resolve.alias instead
* `@swc/core` requires baseUrl and paths
  > [swc] failed to handle: base_dir(`./`) must be absolute. Please ensure that `jsc.baseUrl` is specified correctly. This cannot be deduced by SWC itself because SWC is a transpiler and it does not try to resolve project details. In other works, SWC does not know which directory should be used as a base directory. It can be deduced if `.swcrc` is used, but if not, there are many candidates. e.g. the directory containing `package.json`, or the current working directory. Because of that, the caller (typically the developer of the JavaScript package) should specify it. If you see this error, please report an issue to the package author.