### PR TITLE
Enable global CLI options for `vavite serve` command

### DIFF
--- a/packages/vavite/src/cli.ts
+++ b/packages/vavite/src/cli.ts
@@ -65,15 +65,17 @@ function cleanOptions<Options extends GlobalCLIOptions>(
 }
 
 cli
-	.command("[root]", "Build for production")
-	.alias("build")
 	.option("-c, --config <file>", `[string] use specified config file`)
 	.option("--base <path>", `[string] public base path (default: /)`)
 	.option("-l, --logLevel <level>", `[string] info | warn | error | silent`)
 	.option("--clearScreen", `[boolean] allow/disable clear screen when logging`)
 	.option("-d, --debug [feat]", `[string | boolean] show debug logs`)
 	.option("-f, --filter <filter>", `[string] filter debug logs`)
-	.option("-m, --mode <mode>", `[string] set env mode`)
+	.option("-m, --mode <mode>", `[string] set env mode`);
+
+cli
+	.command("[root]", "Build for production")
+	.alias("build")
 	.option("--target <target>", `[string] transpile target (default: 'modules')`)
 	.option("--outDir <dir>", `[string] output directory (default: dist)`)
 	.option(


### PR DESCRIPTION
I tried using the `vavite serve` command, and I realized that I couldn't use the `--config` option, even though that option is available for the `vavite` command.

Looking at the source code, I saw that there are several CLI options which are _supposed_ to be global but actually aren't.

Turns out, it's a simple change to fix this 😄 

Now when you run `vavite --help` here's what you see:

```
Usage:
  $ vavite [root]

Commands:
  [root]        Build for production
  serve [root]  Start a dev server

For more info, run any command with the `--help` flag:
  $ vavite --help
  $ vavite serve --help

Options:
  --target <target>             [string] transpile target (default: 'modules') 
  --outDir <dir>                [string] output directory (default: dist) 
  --assetsDir <dir>             [string] directory under outDir to place assets in (default: _assets) 
  --assetsInlineLimit <number>  [number] static asset base64 inline threshold in bytes (default: 4096) 
  --ssr [entry]                 [string] build specified entry for server-side rendering 
  --sourcemap                   [boolean] output source maps for build (default: false) 
  --minify [minifier]           [boolean | "terser" | "esbuild"] enable/disable minification, or specify minifier to use (default: esbuild) 
  --manifest                    [boolean] emit build manifest json 
  --ssrManifest                 [boolean] emit ssr manifest json 
  --emptyOutDir                 [boolean] force empty outDir when it's outside of root 
  -w, --watch                   [boolean] rebuilds when modules have changed on disk 
  --force                       [boolean] force the optimizer to ignore the cache and re-bundle (experimental) 
  -c, --config <file>           [string] use specified config file 
  --base <path>                 [string] public base path (default: /) 
  -l, --logLevel <level>        [string] info | warn | error | silent 
  --clearScreen                 [boolean] allow/disable clear screen when logging 
  -d, --debug [feat]            [string | boolean] show debug logs 
  -f, --filter <filter>         [string] filter debug logs 
  -m, --mode <mode>             [string] set env mode 
  -h, --help                    Display this message 
  -v, --version                 Display version number
```

And when you run `vavite serve --help`, here's what you see:

```
Usage:
  $ vavite serve [root]

Options:
  --host [host]           [string] specify hostname 
  --port <port>           [number] specify port 
  --https                 [boolean] use TLS + HTTP/2 
  --open [path]           [boolean | string] open browser on startup 
  --cors                  [boolean] enable CORS 
  --strictPort            [boolean] exit if specified port is already in use 
  --force                 [boolean] force the optimizer to ignore the cache and re-bundle 
  --use-loader            [boolean] use ESM loader (experimental) 
  -c, --config <file>     [string] use specified config file 
  --base <path>           [string] public base path (default: /) 
  -l, --logLevel <level>  [string] info | warn | error | silent 
  --clearScreen           [boolean] allow/disable clear screen when logging 
  -d, --debug [feat]      [string | boolean] show debug logs 
  -f, --filter <filter>   [string] filter debug logs 
  -m, --mode <mode>       [string] set env mode 
  -h, --help              Display this message 
```
