### PR TITLE
feat: dispose on server restart

### DIFF
--- a/examples/express-server/src/entry.server.ts
+++ b/examples/express-server/src/entry.server.ts
@@ -6,11 +6,18 @@ import barRoute from "./routes/bar";
 
 const app = express();
 
+app.use((req, res, next) => {
+	console.log(`${req.method} ${req.url}`);
+	next();
+});
+
 app.get("/", homeRoute);
 app.get("/foo", fooRoute);
 app.get("/bar", barRoute);
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+console.log("Starting server...");
 const server = app.listen(port, () => {
 	console.log(`Server is running on http://localhost:${port}`);
 });


### PR DESCRIPTION
This PR ensures that `import.meta.hot.dispose` and `import.meta.hot.prune` handlers on server environments are called when the Vite dev server restarts due to config changes or the user invoking the `r` keyboard shortcut. This prevents resource leaks and port conflicts on server restarts.